### PR TITLE
Fix loadEPSG epsg.io url in case of https

### DIFF
--- a/preview.js
+++ b/preview.js
@@ -25,7 +25,7 @@ function loadshp(config, returnData) {
     encoding = typeof config.encoding != 'utf-8' ? config.encoding : 'utf-8';
     EPSG = typeof config.EPSG != 'undefined' ? config.EPSG : 4326;
 
-    loadEPSG('http://epsg.io/'+EPSG+'.js', function() {
+    loadEPSG('//epsg.io/'+EPSG+'.js', function() {
         if(EPSG == 3821)
             proj4.defs([
                 ['EPSG:3821', '+proj=tmerc +ellps=GRS67 +towgs84=-752,-358,-179,-.0000011698,.0000018398,.0000009822,.00002329 +lat_0=0 +lon_0=121 +x_0=250000 +y_0=0 +k=0.9999 +units=m +no_defs']


### PR DESCRIPTION
@gipong many thanks for this awesome library. However, i've been facing a minor issue while using your library on a website enable with https. In such case, trying to get from http://epsg.io will fail (mixed origin http/https). I've fixed it easily by letting browser take it either from http/https.
Hope this helps